### PR TITLE
Windows build failing due to bin/ in start and prod section

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "advanced-script": "./bin/advanced-script"
   },
   "scripts": {
-    "start": "npm run prescript && bin/advanced-script start",
-    "prod": "npm run prescript && bin/advanced-script build",
+    "start": "npm run prescript && cross-env bin/advanced-script start",
+    "prod": "npm run prescript && cross-env bin/advanced-script build",
     "prod:start": "npm run prod && node build/server/main.js",
     "clean": "rimraf build/client/* build/server/* lib/* bin/*",
     "test": "npm run prepublish && npm run prod",


### PR DESCRIPTION
Fix windows build by using cross-env to support cross environment path separators