### PR TITLE
Enables dev server debugging

### DIFF
--- a/src/hotdev/HotController.js
+++ b/src/hotdev/HotController.js
@@ -160,7 +160,7 @@ export default class HotController
       })
     }
 
-    const newServer = spawn("node", [ this.compiledServer, "--colors" ], {
+    const newServer = spawn("node", [ "--inspect", this.compiledServer, "--colors" ], {
       stdio: [ process.stdin, process.stdout, "pipe" ]
     })
 


### PR DESCRIPTION
Start dev server with —inspect option to allow WebDevTools like debugging