### PR TITLE
Adds hooks to createExpressServer

### DIFF
--- a/src/api/server/createExpressServer.js
+++ b/src/api/server/createExpressServer.js
@@ -137,8 +137,15 @@ export default function createExpressServer(config)
   // @see https://helmetjs.github.io/docs/dont-sniff-mimetype/
   server.use(helmet.noSniff())
 
-  if (hooks.onSecuredServerCreated)
-    hooks.onSecuredServerCreated(server)
+  if (config.customMiddleware)
+    config.customMiddleware.forEach(
+      (middleware) => {
+        if (middleware instanceof Array)
+          server.use(...middleware)
+        else
+          server.use(middleware)
+      }
+    )
 
   // Parse cookies via standard express tooling
   server.use(cookieParser())

--- a/src/api/server/createExpressServer.js
+++ b/src/api/server/createExpressServer.js
@@ -22,7 +22,7 @@ pretty.skipNodeFiles()
 // this will skip all the trace lines about express` core and sub-modules
 pretty.skipPackage("express")
 
-export default function createExpressServer(config, hooks)
+export default function createExpressServer(config)
 {
   // Create our express based server.
   const server = express()

--- a/src/api/server/createExpressServer.js
+++ b/src/api/server/createExpressServer.js
@@ -22,7 +22,7 @@ pretty.skipNodeFiles()
 // this will skip all the trace lines about express` core and sub-modules
 pretty.skipPackage("express")
 
-export default function createExpressServer(config)
+export default function createExpressServer(config, hooks)
 {
   // Create our express based server.
   const server = express()
@@ -136,6 +136,9 @@ export default function createExpressServer(config)
   // does this by setting the X-Content-Type-Options header to nosniff.
   // @see https://helmetjs.github.io/docs/dont-sniff-mimetype/
   server.use(helmet.noSniff())
+
+  if (hook.onSecuredServerCreated)
+    hook.onSecuredServerCreated(server)
 
   // Parse cookies via standard express tooling
   server.use(cookieParser())

--- a/src/api/server/createExpressServer.js
+++ b/src/api/server/createExpressServer.js
@@ -137,8 +137,8 @@ export default function createExpressServer(config, hooks)
   // @see https://helmetjs.github.io/docs/dont-sniff-mimetype/
   server.use(helmet.noSniff())
 
-  if (hook.onSecuredServerCreated)
-    hook.onSecuredServerCreated(server)
+  if (hooks.onSecuredServerCreated)
+    hooks.onSecuredServerCreated(server)
 
   // Parse cookies via standard express tooling
   server.use(cookieParser())


### PR DESCRIPTION
Allows to plug in own middleware to server if e.g. the body must not be parsed before using the middleware