### PR TITLE
fix(webpack): make ChunkNames compatible with external dll-delegated chunk

### DIFF
--- a/src/webpack/plugins/ChunkNames.js
+++ b/src/webpack/plugins/ChunkNames.js
@@ -18,7 +18,9 @@ function generateChunkName(request, rawRequest) {
 
   var isExternal = relative.startsWith("node_modules" + path.sep)
   if (isExternal) {
-    relative = rawRequest
+    // if the module is an DelegatedModule, the rawRequest will be undefined since it does not have this property.
+    // However, the userRequest property can supplement rawRequest in this situation
+    relative = rawRequest || request
   }
 
   // Strip useless helper folder structure


### PR DESCRIPTION
The module in chunk.modules[0] does not necessarily be a NormalModule which has well-defined userRequest and rawRequest. It could be a DelegatedModule when the chunk is sealed in an external dll files. In this case, the rawRequest will be undefined since a DelegatedModule does not have this property. However, the userRequest property can supplement rawRequest well in this situation.

A minimal webpack dll configuration can be found [here](https://gist.github.com/Eoksni/83d1f1559e0ec00d0e89c33a6d763049). Say if you seal `react` on the dll and use code-splitting `import('react').then()` on the entry, the `ChunkNames` will complain since `rawRequest` is `undefined`.